### PR TITLE
削除処理のテストコードを追加

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,9 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "fish_list/main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "fish_list/main" ]
 
 permissions:
   contents: read

--- a/src/main/java/com/moriwaki/java10thtopic/controller/FishController.java
+++ b/src/main/java/com/moriwaki/java10thtopic/controller/FishController.java
@@ -9,6 +9,7 @@ import com.moriwaki.java10thtopic.request.FishUpdateRequest;
 import com.moriwaki.java10thtopic.response.FishResponse;
 import com.moriwaki.java10thtopic.service.FishService;
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.ibatis.annotations.Delete;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -79,6 +80,13 @@ public class FishController {
     public ResponseEntity<String> update(@RequestBody FishUpdateRequest fishUpdateRequest) {
         fishService.update(fishUpdateRequest.updateToFish());
         return ResponseEntity.ok("fish date updated");
+    }
+
+    //削除処理
+    @DeleteMapping("/fishes/{id}")
+    public ResponseEntity<String> delete(@PathVariable("id") int id){
+        fishService.delete(id);
+        return ResponseEntity.ok("fish date deleted");
     }
 
 }

--- a/src/main/java/com/moriwaki/java10thtopic/controller/FishController.java
+++ b/src/main/java/com/moriwaki/java10thtopic/controller/FishController.java
@@ -9,7 +9,6 @@ import com.moriwaki.java10thtopic.request.FishUpdateRequest;
 import com.moriwaki.java10thtopic.response.FishResponse;
 import com.moriwaki.java10thtopic.service.FishService;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.ibatis.annotations.Delete;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -71,7 +70,7 @@ public class FishController {
     public ResponseEntity<FishResponse> insert(@RequestBody FishRequest fishRequest, UriComponentsBuilder uriBuilder) {
         Fish fish = fishService.insert(fishRequest.convertToFish());
         URI location = uriBuilder.path("/fishes/{id}").buildAndExpand(fish.getId()).toUri();
-        FishResponse body = new FishResponse("fish　date created");
+        FishResponse body = new FishResponse("fish　data created");
         return ResponseEntity.created(location).body(body);
     }
 
@@ -79,14 +78,14 @@ public class FishController {
     @PatchMapping("/fishes")
     public ResponseEntity<String> update(@RequestBody FishUpdateRequest fishUpdateRequest) {
         fishService.update(fishUpdateRequest.updateToFish());
-        return ResponseEntity.ok("fish date updated");
+        return ResponseEntity.ok("fish data updated");
     }
 
     //削除処理
     @DeleteMapping("/fishes/{id}")
     public ResponseEntity<String> delete(@PathVariable("id") int id){
         fishService.delete(id);
-        return ResponseEntity.ok("fish date deleted");
+        return ResponseEntity.ok("fish data deleted");
     }
 
 }

--- a/src/main/java/com/moriwaki/java10thtopic/mapper/FishMapper.java
+++ b/src/main/java/com/moriwaki/java10thtopic/mapper/FishMapper.java
@@ -9,11 +9,11 @@ import java.util.Optional;
 @Mapper
 public interface FishMapper {
 
-    //Read処理　全件表示
+    //Read処理　全件表示　表示用DB(fish_view)呼び出し
     @Select("SELECT * FROM fish_view")
     List<FishView> findAll();
 
-    //Read処理　検索表示
+    //Read処理　検索表示　表示用DB(fish_view)呼び出し
     @Select("SELECT * FROM fish_view WHERE id = #{id}")
     Optional<FishView> findById(int id);
 
@@ -30,8 +30,12 @@ public interface FishMapper {
     @Update("UPDATE fishes SET name = #{name}, priceInYen = #{priceInYen}, inventoryAmount = #{inventoryAmount} WHERE id = #{id}")
     void update(Fish fish);
 
-    //PATCH処理時に、既に存在しているIDか確認
+    //PATCH処理、DELETE処理時に、既に存在しているIDか確認
     @Select("SELECT * FROM fishes WHERE id = #{id}")
     Optional<Fish> checkById(int id);
+
+    //DELETE処理　削除処理
+    @Delete("DELETE FROM fishes WHERE id = #{id}")
+    void delete(int id);
 
 }

--- a/src/main/java/com/moriwaki/java10thtopic/service/FishService.java
+++ b/src/main/java/com/moriwaki/java10thtopic/service/FishService.java
@@ -47,9 +47,10 @@ public class FishService {
     }
 
     //DELETE処理　削除処理 Mapper呼び出し
-    public void delete(int id) {
+    public int delete(int id) {
         this.fishMapper.checkById(id).orElseThrow(() -> new FishNotFoundException("id does not exist"));
         fishMapper.delete(id);
+        return id;
     }
 
 }

--- a/src/main/java/com/moriwaki/java10thtopic/service/FishService.java
+++ b/src/main/java/com/moriwaki/java10thtopic/service/FishService.java
@@ -46,4 +46,10 @@ public class FishService {
         return fish;
     }
 
+    //DELETE処理　削除処理 Mapper呼び出し
+    public void delete(int id) {
+        this.fishMapper.checkById(id).orElseThrow(() -> new FishNotFoundException("id does not exist"));
+        fishMapper.delete(id);
+    }
+
 }

--- a/src/test/java/com/moriwaki/java10thtopic/service/FishServiceTest.java
+++ b/src/test/java/com/moriwaki/java10thtopic/service/FishServiceTest.java
@@ -92,7 +92,7 @@ class FishServiceTest {
     }
 
     @Test
-    public void 存在しないデータを更新か削除しようした際の例外処理テスト() throws FishNotFoundException {
+    public void 存在しないデータを更新しようした際の例外処理テスト() throws FishNotFoundException {
         Fish fish = new Fish(999, "ウナギ", 5322, 13);
         doReturn(Optional.empty()).when(fishMapper).checkById(999);
         assertThrows(FishNotFoundException.class, () -> {
@@ -104,10 +104,20 @@ class FishServiceTest {
     @Test
     public void データの削除処理テスト() {
         Fish fish = new Fish(1, "ウナギ", 5322, 13);
-        doNothing().when(fishMapper).delete(1);
         doReturn(Optional.of(fish)).when(fishMapper).checkById(1);
+        doNothing().when(fishMapper).delete(1);
         int actual = fishService.delete(1);
         assertThat(actual).isEqualTo(1);
         verify(fishMapper, times(1)).delete(1);
     }
+
+    @Test
+    public void 存在しないデータを削除しようした際の例外処理テスト() throws FishNotFoundException {
+        doReturn(Optional.empty()).when(fishMapper).checkById(999);
+        assertThrows(FishNotFoundException.class, () -> {
+            fishService.delete(999);
+        });
+        verify(fishMapper, times(1)).checkById(999);
+    }
+
 }

--- a/src/test/java/com/moriwaki/java10thtopic/service/FishServiceTest.java
+++ b/src/test/java/com/moriwaki/java10thtopic/service/FishServiceTest.java
@@ -29,7 +29,7 @@ class FishServiceTest {
     FishMapper fishMapper;
 
     @Test
-    public void 存在するデータのIDを指定したときに正常にデータが返されること() {
+    public void 指定したIDデータの検索表示テスト() {
         doReturn(Optional.of(new FishView(1, "タイ", "1036円/kg", "5kg"))).when(fishMapper).findById(1);
         FishView actual = fishService.findById(1);
         assertThat(actual).isEqualTo(new FishView(1, "タイ", "1036円/kg", "5kg"));
@@ -37,20 +37,20 @@ class FishServiceTest {
     }
 
     @Test
-    public void 存在しないデータのIDを指定したときに例外処理が返されること() throws FishNotFoundException {
+    public void 指定したIDが存在しない場合の例外処理テスト() throws FishNotFoundException {
         doReturn(Optional.empty()).when(fishMapper).findById(100);
         assertThrows(FishNotFoundException.class, () -> {
-                    fishService.findById(100);
-                });
+            fishService.findById(100);
+        });
         verify(fishMapper, times(1)).findById(100);
     }
 
     @Test
-    void すべてのデータが取得できること() {
+    void 全データの表示テスト() {
         List<FishView> fishList = Arrays.asList(
                 new FishView(1, "タイ", "1036円/kg", "5kg"),
                 new FishView(2, "カニ", "1026円/kg", "7kg"),
-                new FishView(3, "マグロ", "4333円/kg","10kg"));
+                new FishView(3, "マグロ", "4333円/kg", "10kg"));
         doReturn(fishList).when(fishMapper).findAll();
         List<FishView> fishes = fishService.findAll();
         assertThat(fishes)
@@ -58,12 +58,12 @@ class FishServiceTest {
                 .contains(
                         new FishView(1, "タイ", "1036円/kg", "5kg"),
                         new FishView(2, "カニ", "1026円/kg", "7kg"),
-                        new FishView(3, "マグロ", "4333円/kg","10kg"));
+                        new FishView(3, "マグロ", "4333円/kg", "10kg"));
         verify(fishMapper, times(1)).findAll();
     }
 
     @Test
-    public void 存在しないデータを新規登録すること() {
+    public void データの新規登録テスト() {
         Fish fish = new Fish(null, "カキ", 1003, 15);
         doNothing().when(fishMapper).insert(fish);
         Fish actual = fishService.insert(fish);
@@ -72,7 +72,7 @@ class FishServiceTest {
     }
 
     @Test
-    public void 新規登録しようとしたデータ名が既に存在した場合に例外処理が返されること() throws FishAlreadyExistsException {
+    public void 新規登録しようとしたデータ名が既に存在した場合の例外処理テスト() throws FishAlreadyExistsException {
         Fish fish = new Fish(1, "カキ", 1003, 15);
         doReturn(Optional.of(fish)).when(fishMapper).checkByName("カキ");
         assertThrows(FishAlreadyExistsException.class, () -> {
@@ -82,7 +82,7 @@ class FishServiceTest {
     }
 
     @Test
-    public void 存在しているデータを更新すること() {
+    public void データの更新処理テスト() {
         Fish fish = new Fish(1, "ウナギ", 5322, 13);
         doNothing().when(fishMapper).update(fish);
         doReturn(Optional.of(fish)).when(fishMapper).checkById(1);
@@ -92,7 +92,7 @@ class FishServiceTest {
     }
 
     @Test
-    public void 存在しないデータを更新しようしたときに例外処理が返されること() throws FishNotFoundException {
+    public void 存在しないデータを更新か削除しようした際の例外処理テスト() throws FishNotFoundException {
         Fish fish = new Fish(999, "ウナギ", 5322, 13);
         doReturn(Optional.empty()).when(fishMapper).checkById(999);
         assertThrows(FishNotFoundException.class, () -> {
@@ -101,4 +101,13 @@ class FishServiceTest {
         verify(fishMapper, times(1)).checkById(999);
     }
 
+    @Test
+    public void データの削除処理テスト() {
+        Fish fish = new Fish(1, "ウナギ", 5322, 13);
+        doNothing().when(fishMapper).delete(1);
+        doReturn(Optional.of(fish)).when(fishMapper).checkById(1);
+        int actual = fishService.delete(1);
+        assertThat(actual).isEqualTo(1);
+        verify(fishMapper, times(1)).delete(1);
+    }
 }


### PR DESCRIPTION
概要
FishServiceTestにて「データの削除処理テスト」という名前で
テストコードを追加。
内容としては
・fishService_deleteを呼び出し、テスト内容が正しく渡されているか確認。
・fishMapper_deleteは呼ばれても対応しないように設定。
・fishMapper_findByIdにて、存在しているIdであることを返すよう設定。
・fishMapper_deleteが1回呼ばれているか確認。

結果
テストが実施された結果、問題ないことを確認した。
https://github.com/Moriwaki-9082/Java-10th-topic/pull/11/commits/34d6eeb8ced20b51d8b42c743afe9459dba14c6e#diff-d0c75862bb2830bcfe6dc658869b4630c4f038d988f9e6bd4a23876b723783bfR104-R112
![スクリーンショット 2024-01-14 112503](https://github.com/Moriwaki-9082/Java-10th-topic/assets/147434025/f1b9e1b7-cfed-4806-84d1-696afcb1fe7e)